### PR TITLE
Change GitHub action trigger for release branches

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -1,13 +1,16 @@
 name: Build and release a new version
 
 on:
-  push:
+  pull_request_target:
+    types:
+      - closed
     branches:
-      - release-**
+      - main
 
 jobs:
-  build:
-    name: Build Python Package
+  run_if:
+    if: (startsWith(github.head_ref, 'release-') && github.event.pull_request.merged == true)
+    name: Make a release
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Improve based: 

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges-1

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target