### PR TITLE
Update checkout action to fetch all of history

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
     
       - name: Set up Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
Turns out the default behaviour for the checkout action is to do a shallow clone. Which breaks the `git log` step I am using to generate the release notes. Changing this to download full history, but we probably need a different solution. Perhaps at some point, we can switch to Changelog.md approach. 

Source: https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches