### PR TITLE
Add step to upload artifacts

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,11 +1,11 @@
-name: Build Python Package
+name: Publish to PyPI
 
 on:
-  pull_request:
-    types: [opened, reopened]
+  release:
+    types: [published]
 
 jobs:
-  build:
+  publish:
     name: Build Python Package
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -54,4 +54,9 @@ jobs:
                                   --notes "$RELEASE_NOTES" \
                                   --target "$GITHUB_SHA" \
                                   $RELEASE_ARTIFACTS
-
+      
+      - name: Upload Artifacts
+        uses: actions/checkout@v2
+        with:
+          name: ${{ env.NEXT_CLI_VERSION }}
+          path: ./dist/*$NEXT_CLI_VERSION*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyline-profiler"
-version = "0.10.4"
+version = "0.10.3"
 description = "Interactive performance profiling and debugging tool for PyTorch neural networks."
 authors = ["Geoffrey Yu <gxyu@cs.toronto.edu>"]
 maintainers = ["Akbar Nurlybayev <akbar.nur@gmail.com>"]


### PR DESCRIPTION
In order to publish consistently, we need to store build artifacts on GitHub. Turns out there is an action for that:
* https://github.com/actions/upload-artifact
* https://github.com/actions/download-artifact